### PR TITLE
fix: clear board cells visually on reset

### DIFF
--- a/script.js
+++ b/script.js
@@ -1,7 +1,6 @@
 const board = document.querySelectorAll(".cell");
 const statusText = document.getElementById("status");
 const resetBtn = document.getElementById("resetBtn");
-
 let currentPlayer = "X";
 let gameActive = true;
 let gameState = ["", "", "", "", "", "", "", "", ""];
@@ -20,21 +19,17 @@ const winningConditions = [
 function handleCellClick(e) {
   const clickedCell = e.target;
   const cellIndex = clickedCell.getAttribute("data-index");
-
   if (gameState[cellIndex] !== "" || !gameActive) {
     return;
   }
-
   gameState[cellIndex] = currentPlayer;
   clickedCell.innerText = currentPlayer;
-
   checkResult();
   statusText.innerText = `Player ${currentPlayer}'s turn`;
 }
 
 function checkResult() {
   let roundWon = false;
-
   for (let i = 0; i < winningConditions.length; i++) {
     const [a, b, c] = winningConditions[i];
     if (
@@ -49,13 +44,11 @@ function checkResult() {
       break;
     }
   }
-
   if (roundWon) {
     statusText.innerText = `Player ${currentPlayer} wins!`;
     gameActive = false;
     return;
   }
-
   if (!gameState.includes("")) {
     statusText.innerText = "It's a draw!";
     gameActive = false;
@@ -67,7 +60,8 @@ function resetGame() {
   currentPlayer = "X";
   gameState = ["", "", "", "", "", "", "", "", ""];
   statusText.innerText = `Player X's turn`;
+  board.forEach(cell => cell.innerText = ""); // ✅ FIX: clear board visually
 }
-board.forEach(cell => cell.addEventListener("click", handleCellClick));
 
+board.forEach(cell => cell.addEventListener("click", handleCellClick));
 resetBtn.addEventListener("click", resetGame);


### PR DESCRIPTION
## 📌 Description
Brief description of what this PR does.
Fixed a bug where clicking the Reset button would reset the game state internally but leave the X and O symbols still visible on the board.

## 🔗 Related Issue
Closes #8


## 🛠 Changes Made
- Added `board.forEach(cell => cell.innerText = "")` inside the `resetGame()` function to clear all cell contents visually on reset


## 📷 Screenshots (if applicable)
Before Reset:
<img width="1920" height="1080" alt="Screenshot (165)" src="https://github.com/user-attachments/assets/7bb89bb2-89dd-4e0f-83fe-8503608d870b" />
After Reset:
<img width="1920" height="1080" alt="Screenshot (166)" src="https://github.com/user-attachments/assets/cd359f17-0576-4d5b-b69e-b7546161a204" />




## ✅ Checklist
- [x] I have tested my changes
- [x] My code follows project guidelines
- [x] I have linked the related issue
