### PR TITLE
fixed the bug on change player button

### DIFF
--- a/script.js
+++ b/script.js
@@ -175,3 +175,15 @@ function drawWinLine(pattern) {
 cells.forEach(cell => cell.addEventListener("click", handleCellClick));
 resetBtn.addEventListener("click", resetGame);
 updateLeaderboard();
+// Change Players Button Fix
+changeNamesBtn.addEventListener("click", () => {
+  gameContainer.style.display = "none";
+  setupContainer.style.display = "block";
+
+  // Clear input fields (optional but clean)
+  document.getElementById("p1Input").value = "";
+  document.getElementById("p2Input").value = "";
+
+  // Reset board state
+  resetGame();
+});


### PR DESCRIPTION
## 📌 Description
Brief description of what this PR does.
This PR fixes the issue where the "Change Players" button was not functioning when clicked.

Previously, the button had no event listener attached, so clicking it did not perform any action. This update adds the necessary JavaScript event listener to properly toggle back to the player setup screen when the button is clicked.

No changes were made to the HTML structure or CSS styling. The fix only adds the required JavaScript logic to ensure the feature works as intended.
---

## 🔗 Related Issue
Closes #24

---

## 🛠 Changes Made
- No changes were made to the HTML structure or CSS styling. The fix only adds the required JavaScript logic to ensure the feature works as intended.
---
- 
- 

---

## 📷 Screenshots (if applicable)

---

## ✅ Checklist
- [✅ ] I have tested my changes
- [✅ ] My code follows project guidelines
- [✅ ] I have linked the related issue
